### PR TITLE
Fork crate as `shared_memory_extended`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "shared_memory"
+name = "shared_memory_extended"
 description = "A user friendly crate that allows you to share memory between processes"
-version = "0.12.5"
+version = "0.13.0"
 authors = ["ElasT0ny <elast0ny00@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
 #Extra fields for crates.io
 readme = "README.md"
-documentation = "https://docs.rs/shared_memory"
-repository = "https://github.com/elast0ny/shared_memory-rs"
+documentation = "https://docs.rs/shared_memory_extended"
+repository = "https://github.com/phil-opp/shared_memory"
 keywords = ["shmem", "shared", "memory", "inter-process", "process"]
 categories = [
     "os::unix-apis",
@@ -39,5 +39,5 @@ win-sys = "0.3"
 
 [dev-dependencies]
 raw_sync = "0.1"
-clap = {version = "4", features = ["derive"]}
+clap = { version = "4", features = ["derive"] }
 env_logger = "0"

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ A crate that allows you to share memory between __processes__. Fork of [elast0ny
 
 This crate provides lightweight wrappers around shared memory APIs in an OS agnostic way. It is intended to be used with it's sister crate [raw_sync](https://github.com/elast0ny/raw_sync-rs) which provide simple primitves to synchronize access to the shared memory (Mutex, RwLock, Events, etc...).
 
-| raw_sync |
-|----|
-|[![crates.io](https://img.shields.io/crates/v/raw_sync.svg)](https://crates.io/crates/raw_sync) [![docs.rs](https://docs.rs/raw_sync/badge.svg)](https://docs.rs/raw_sync/)|
+| raw_sync                                                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [![crates.io](https://img.shields.io/crates/v/raw_sync.svg)](https://crates.io/crates/raw_sync) [![docs.rs](https://docs.rs/raw_sync/badge.svg)](https://docs.rs/raw_sync/) |
 
 ## Usage
 
 For usage examples, see code located in [examples/](examples/) :
 
-  | Examples | Description |
-  |----------|-------------|
-  |[event](examples/event.rs)| Shows the use of shared events through shared memory|
-  |[mutex](examples/mutex.rs)| Shows the use of a shared mutex through shared memory|
+  | Examples                   | Description                                           |
+  | -------------------------- | ----------------------------------------------------- |
+  | [event](examples/event.rs) | Shows the use of shared events through shared memory  |
+  | [mutex](examples/mutex.rs) | Shows the use of a shared mutex through shared memory |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# shared_memory
-[![Build Status](https://github.com/elast0ny/shared_memory-rs/workflows/build/badge.svg)](https://github.com/elast0ny/shared_memory-rs/actions?query=workflow%3Abuild)
+# shared_memory_extended
+[![Build Status](https://github.com/phil-opp/shared_memory/workflows/build/badge.svg)](https://github.com/phil-opp/shared_memory/actions?query=workflow%3Abuild)
 [![crates.io](https://img.shields.io/crates/v/shared_memory.svg)](https://crates.io/crates/shared_memory)
 [![mio](https://docs.rs/shared_memory/badge.svg)](https://docs.rs/shared_memory/)
-[![Lines of Code](https://tokei.rs/b1/github/elast0ny/shared_memory-rs?category=code)](https://tokei.rs/b1/github/elast0ny/shared_memory-rs?category=code)
+[![Lines of Code](https://tokei.rs/b1/github/phil-opp/shared_memory?category=code)](https://tokei.rs/b1/github/phil-opp/shared_memory?category=code)
 
-A crate that allows you to share memory between __processes__.
+A crate that allows you to share memory between __processes__. Fork of [elast0ny/shared_memory](https://github.com/elast0ny/shared_memory).
 
 This crate provides lightweight wrappers around shared memory APIs in an OS agnostic way. It is intended to be used with it's sister crate [raw_sync](https://github.com/elast0ny/raw_sync-rs) which provide simple primitves to synchronize access to the shared memory (Mutex, RwLock, Events, etc...).
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.13.0
+
+- Create crate as fork of `shared_memory` crate
+- Add support for read-only mapping
+
 # 0.12.5
 - Update dependencies
 - Use minimal features for `nix` on unix systems

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use std::thread;
 
 use clap::Parser;
-use shared_memory::*;
+use shared_memory_extended::*;
 
 /// Spawns N threads that increment a value to 100
 #[derive(Parser)]

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -1,5 +1,5 @@
 use raw_sync::{events::*, Timeout};
-use shared_memory::*;
+use shared_memory_extended::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -3,7 +3,7 @@ use std::thread;
 
 use clap::Parser;
 use raw_sync::locks::*;
-use shared_memory::*;
+use shared_memory_extended::*;
 
 /// Spawns N threads that increment a value to 10 using a mutex
 #[derive(Parser)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A thin wrapper around shared memory system calls
 //!
-//! For help on how to get started, take a look at the [examples](https://github.com/elast0ny/shared_memory-rs/tree/master/examples) !
+//! For help on how to get started, take a look at the [examples](https://github.com/phil-opp/shared_memory/tree/master/examples) !
 
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use shared_memory::ShmemConf;
+use shared_memory_extended::ShmemConf;
 
 #[test]
 fn create_new() {

--- a/tests/posix_semantics.rs
+++ b/tests/posix_semantics.rs
@@ -1,4 +1,4 @@
-use shared_memory::ShmemConf;
+use shared_memory_extended::ShmemConf;
 use std::sync::mpsc::channel;
 use std::thread;
 


### PR DESCRIPTION
There was no reaction on https://github.com/elast0ny/shared_memory/pull/100 for multiple months, so we decided to create a fork for now.
